### PR TITLE
You need an absolute URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vrview"]
+	path = vrview
+	url = git@github.com:googlevr/vrview.git

--- a/templates/2-remote.html
+++ b/templates/2-remote.html
@@ -8,7 +8,7 @@
     function onVrViewLoad() {
       // Selector '#vrview' finds element with id 'vrview'.
       var vrView = new VRView.Player('#vrview', {
-        image: '/static/images/amsterdam1.jpeg',
+        image: '{{ url_for("static", filename="images/amsterdam1.jpeg", _external=True) }}',
         is_stereo: false,
         width: 600,
         height: 300
@@ -20,7 +20,7 @@
 <body>
   <h2>Attempt 2: with VRView remotely</h2>
   <p>See <a href="https://developers.google.com/vr/develop/web/vrview-web" target="_blank">here</a> for info</p>
-  <img src="/static/images/amsterdam1.jpeg" width="500px"></img>
+  <img src="{{ url_for("static", filename="images/amsterdam1.jpeg") }}" width="500px"></img>
   <h3>360 view below this</h3>
   <hr />
   <div id='vrview'></div>


### PR DESCRIPTION
If the file is being served by your webserver, the VRview javascript needs to know how to find it.

Since in the `2-remote.html` case the actual JS file is on google servers somewhere it uses `https://storage.googleapis.com` as it's base url so `/static/images/amsterdam.jpeg` will end up being `https://storage.googleapis.com/static/images/amsterdam.jpeg` which google will 404.

For the one hosted on amazon you were almost there but you need to set up CORS (which is a security feature to stop random javascript being able to access everything as you) on [S3](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/add-cors-configuration.html) without CORS a random advert would be able to just request any url on say facebook as you if you were logged in. CORS is a way of saying, requests from such and such url (in this case `https://storage.googleapis.com` are safe) which is why it has to be set on the side serving the stuff.

---
git stuff, you should commit your copy of `.gitmodules` that way when you clone it again, it knows where to find it. I think the one I added should be the same